### PR TITLE
fix: change the response type of authentication to match de rcon protocol

### DIFF
--- a/Internal/PacketType.cs
+++ b/Internal/PacketType.cs
@@ -5,6 +5,7 @@
         Error = -1,
         MultiPacket = 0,
         Command = 2,
+        LoginResponse = 2,
         Login = 3,
     }
 }

--- a/rcon.cs
+++ b/rcon.cs
@@ -57,7 +57,7 @@ namespace rcon
                         requestId = -1;
                     }
 
-                    byte[] packet = PacketBuilder.CreatePacket(requestId, type, response_payload);
+                    byte[] packet = PacketBuilder.CreatePacket(requestId, PacketType.LoginResponse, response_payload);
 
                     socket.Send(packet);
                     break;


### PR DESCRIPTION
The response of the authentication (login) was returning the same type as login request (3), however, the correct response is 2 as [Valve describes in RCON reference](https://developer.valvesoftware.com/wiki/Source_RCON_Protocol#SERVERDATA_AUTH_RESPONSE).

It was causing some rcon clients can't work with this rcon server, since they don't accepted the authentication response, even if it's a successful login.

I did the fix and tested in my bepinex (valheim) server, it worked like a charm.