### PR TITLE
Fixes the memory leak

### DIFF
--- a/.idea/.idea.BepInEx.dir/.idea/.gitignore
+++ b/.idea/.idea.BepInEx.dir/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/modules.xml
+/contentModel.xml
+/projectSettingsUpdater.xml
+/.idea.BepInEx.iml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.BepInEx.dir/.idea/.name
+++ b/.idea/.idea.BepInEx.dir/.idea/.name
@@ -1,0 +1,1 @@
+BepInEx

--- a/.idea/.idea.BepInEx.dir/.idea/indexLayout.xml
+++ b/.idea/.idea.BepInEx.dir/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.BepInEx.dir/.idea/vcs.xml
+++ b/.idea/.idea.BepInEx.dir/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/AbstractCommand.cs
+++ b/AbstractCommand.cs
@@ -4,7 +4,7 @@ namespace rcon
 {
     public abstract class AbstractCommand : ICommand
     {
-        protected BaseUnityPlugin Plugin { get; private set; }
+        protected BaseUnityPlugin? Plugin { get; private set; }
 
         void ICommand.setOwner(BaseUnityPlugin owner)
         {

--- a/App.config
+++ b/App.config
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?><configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="0Harmony" publicKeyToken="null" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.7.0.0" newVersion="2.7.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Mono.Cecil" publicKeyToken="50cebf1cceb9d05e" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.11.4.0" newVersion="0.11.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="MonoMod.Utils" publicKeyToken="null" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-21.12.13.1" newVersion="21.12.13.1" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Internal/AsynchronousSocketListener.cs
+++ b/Internal/AsynchronousSocketListener.cs
@@ -3,169 +3,171 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
 
-namespace rcon.Internal
+namespace rcon.Internal;
+
+internal class AsynchronousSocketListener(IPAddress ipAddress, int port)
 {
-    internal class AsynchronousSocketListener
+    internal delegate void MessageReceived(Socket socket, int requestId, PacketType type, string payload);
+    internal event MessageReceived? OnMessage;
+
+    // Create a TCP/IP socket.  
+    private readonly Socket _listener = new(ipAddress.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+    private readonly List<StateObject> _clients = [];
+    
+    internal void StartListening()
     {
-        internal delegate void MessageReceived(Socket socket, int requestId, PacketType type, string payload);
-        internal event MessageReceived OnMessage;
-        private Socket listener;
-
-        private List<StateObject> clients = new List<StateObject>();
-
-        internal void StartListening(int port)
+        // Bind the socket to the local endpoint and listen for incoming connections.  
+        try
         {
-            IPAddress ipAddress = IPAddress.Any;
-            IPEndPoint localEndPoint = new IPEndPoint(ipAddress, port);
+            var localEndPoint = new IPEndPoint(ipAddress, port);
 
-            // Create a TCP/IP socket.  
-            listener = new Socket(ipAddress.AddressFamily,
-                SocketType.Stream, ProtocolType.Tcp);
-
-            // Bind the socket to the local endpoint and listen for incoming connections.  
-            try
-            {
-                listener.Bind(localEndPoint);
-                listener.Listen(100);
-            }
-            catch (Exception e)
-            {
-                UnityEngine.Debug.LogError(e.ToString());
-            }
+            _listener.Bind(localEndPoint);
+            _listener.Listen(100);
+            
+            // start listening for the first client
+            _listener.BeginAccept(AcceptCallback, _listener);
         }
-
-        private bool isConnected(Socket c)
+        catch (Exception e)
         {
-            try
+            Debug.LogError(e.ToString());
+        }
+    }
+    
+    private bool IsConnected(Socket? c)
+    {
+        try
+        {
+            if (c is { Connected: true })
             {
-                if (c != null && c != null && c.Connected)
+                if (c.Poll(0, SelectMode.SelectRead))
                 {
-                    if (c.Poll(0, SelectMode.SelectRead))
-                    {
-                        return !(c.Receive(new byte[1], SocketFlags.Peek) == 0);
-                    }
-                    return true;
+                    return c.Receive(new byte[1], SocketFlags.Peek) != 0;
                 }
-                return false;
+                return true;
             }
-            catch
+            return false;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    internal void Update()
+    {
+
+        // copy the original list to an array to prevent errors when removing from the original list.
+        foreach (var state in _clients.ToArray()) 
+            if (!IsConnected(state.WorkSocket))
             {
-                return false;
+                Debug.Log("Rcon client disconnected");
+                state.WorkSocket?.Close();
+                _clients.Remove(state);
             }
+        
+        // memory leak when called inside the Update loop, instead call it after AcceptCallback
+        //_listener?.BeginAccept(AcceptCallback, _listener);
+    }
+
+    internal void AcceptCallback(IAsyncResult ar)
+    {
+        // Signal the main thread to continue.  
+        //allDone.Set();
+
+        // Get the socket that handles the client request.  
+        var listener = (Socket)ar.AsyncState;
+        var handler = listener.EndAccept(ar);
+
+        // Create the state object.  
+        var state = new StateObject
+        {
+            WorkSocket = handler
+        };
+        _clients.Add(state);
+        Debug.Log("Rcon client connected");
+        handler.BeginReceive(state.buffer, 0, StateObject.BufferSize, 0, ReadCallback, state);
+        
+        // start listening for the next client
+        _listener?.BeginAccept(AcceptCallback, _listener);
+    }
+
+    private void ReadCallback(IAsyncResult ar)
+    {
+        var content = string.Empty;
+
+        // Retrieve the state object and the handler socket  
+        // from the asynchronous state object.  
+        var state = (StateObject)ar.AsyncState;
+        var handler = state.WorkSocket;
+
+        if (handler == null)
+            return;
+
+        // Read data from the client socket.
+        int bytesRead = handler.EndReceive(ar);
+        int length = BitConverter.ToInt32(state.buffer, 0);
+        int requestId = BitConverter.ToInt32(state.buffer, sizeof(int));
+        int type = BitConverter.ToInt32(state.buffer, sizeof(int) * 2);
+        length -= sizeof(int) * 3 - 2;
+        byte[] payload = new byte[length];
+        for (var i = 0; i < length; i++)
+        {
+            payload[i] = state.buffer[(sizeof(int) * 3) + i];
         }
 
-        internal void Update()
-        {
+        OnMessage?.Invoke(handler, requestId, (PacketType)type, Encoding.ASCII.GetString(payload));
 
-            for (int i = 0; i < clients.Count; i++)
+        // read another packet probably?
+        state.buffer = new byte[StateObject.BufferSize]; // clear the buffer
+        handler.BeginReceive(state.buffer, 0, StateObject.BufferSize, 0, ReadCallback, state);
+    }
+
+    private void Send(Socket handler, string data)
+    {
+        // Convert the string data to byte data using ASCII encoding.  
+        byte[] byteData = Encoding.ASCII.GetBytes(data);
+
+        // Begin sending the data to the remote device.  
+        handler.BeginSend(byteData, 0, byteData.Length, 0, SendCallback, handler);
+    }
+
+    private void SendCallback(IAsyncResult ar)
+    {
+        try
+        {
+            // Retrieve the socket from the state object.  
+            Socket handler = (Socket)ar.AsyncState;
+
+            // Complete sending the data to the remote device.  
+            int bytesSent = handler.EndSend(ar);
+            Debug.Log($"Sent {bytesSent} bytes to client.");
+
+            handler.Shutdown(SocketShutdown.Both);
+            handler.Close();
+
+        }
+        catch (Exception e)
+        {
+            Debug.LogError(e.ToString());
+        }
+    }
+
+    internal void Close()
+    {
+        if (_listener is { Connected: true })
+        {
+            foreach (var client in _clients)
             {
-                StateObject state = clients[i];
-                if (!isConnected(state.workSocket))
+                if (IsConnected(client.WorkSocket))
                 {
-                    UnityEngine.Debug.Log("Rcon client disconnected");
-                    state.workSocket.Close();
-                    clients.Remove(state);
+                    client.WorkSocket?.Close();
                 }
             }
-
-            listener.BeginAccept(
-                        new AsyncCallback(AcceptCallback),
-                        listener);
+            _listener.Close();
         }
 
-        internal void AcceptCallback(IAsyncResult ar)
-        {
-            // Signal the main thread to continue.  
-            //allDone.Set();
-
-            // Get the socket that handles the client request.  
-            Socket listener = (Socket)ar.AsyncState;
-            Socket handler = listener.EndAccept(ar);
-
-            // Create the state object.  
-            StateObject state = new StateObject();
-            state.workSocket = handler;
-            clients.Add(state);
-            UnityEngine.Debug.Log("Rcon client connected");
-            handler.BeginReceive(state.buffer, 0, StateObject.BufferSize, 0,
-                new AsyncCallback(ReadCallback), state);
-        }
-
-        private void ReadCallback(IAsyncResult ar)
-        {
-            string content = string.Empty;
-
-            // Retrieve the state object and the handler socket  
-            // from the asynchronous state object.  
-            StateObject state = (StateObject)ar.AsyncState;
-            Socket handler = state.workSocket;
-
-            // Read data from the client socket.
-            int bytesRead = handler.EndReceive(ar);
-            int length = BitConverter.ToInt32(state.buffer, 0);
-            int requestId = BitConverter.ToInt32(state.buffer, sizeof(int));
-            int type = BitConverter.ToInt32(state.buffer, sizeof(int) * 2);
-            length -= (sizeof(int) * 3) - 2;
-            byte[] payload = new byte[length];
-            for (int i = 0; i < length; i++)
-            {
-                payload[i] = state.buffer[(sizeof(int) * 3) + i];
-            }
-
-            OnMessage?.Invoke(handler, requestId, (PacketType)type, Encoding.ASCII.GetString(payload));
-
-            // read another packet probably?
-            state.buffer = new byte[StateObject.BufferSize]; // clear the buffer
-            handler.BeginReceive(state.buffer, 0, StateObject.BufferSize, 0,
-                new AsyncCallback(ReadCallback), state);
-        }
-
-        private void Send(Socket handler, string data)
-        {
-            // Convert the string data to byte data using ASCII encoding.  
-            byte[] byteData = Encoding.ASCII.GetBytes(data);
-
-            // Begin sending the data to the remote device.  
-            handler.BeginSend(byteData, 0, byteData.Length, 0,
-                new AsyncCallback(SendCallback), handler);
-        }
-
-        private void SendCallback(IAsyncResult ar)
-        {
-            try
-            {
-                // Retrieve the socket from the state object.  
-                Socket handler = (Socket)ar.AsyncState;
-
-                // Complete sending the data to the remote device.  
-                int bytesSent = handler.EndSend(ar);
-                UnityEngine.Debug.Log($"Sent {bytesSent} bytes to client.");
-
-                handler.Shutdown(SocketShutdown.Both);
-                handler.Close();
-
-            }
-            catch (Exception e)
-            {
-                UnityEngine.Debug.LogError(e.ToString());
-            }
-        }
-
-        internal void Close()
-        {
-            if (listener.Connected)
-            {
-                foreach (var client in clients)
-                {
-                    if (isConnected(client.workSocket))
-                    {
-                        client.workSocket.Close();
-                    }
-                }
-                listener.Close();
-            }
-
-        }
     }
 }

--- a/Internal/StateObject.cs
+++ b/Internal/StateObject.cs
@@ -11,6 +11,6 @@ namespace rcon.Internal
         internal byte[] buffer = new byte[BufferSize];
 
         // Client socket.
-        internal Socket workSocket = null;
+        internal Socket? WorkSocket = null;
     }
 }

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="BepInEx.BaseLib" version="5.4.21" targetFramework="net48" />
+  <package id="BepInEx.Core" version="5.4.21" targetFramework="net48" />
+  <package id="HarmonyX" version="2.7.0" targetFramework="net48" />
+  <package id="Mono.Cecil" version="0.11.4" targetFramework="net48" />
+  <package id="MonoMod.RuntimeDetour" version="21.12.13.1" targetFramework="net48" />
+  <package id="MonoMod.Utils" version="21.12.13.1" targetFramework="net48" />
+  <package id="UnityEngine.Modules" version="2023.2.14" targetFramework="net48" developmentDependency="true" />
+</packages>

--- a/rcon.cs
+++ b/rcon.cs
@@ -4,168 +4,167 @@ using rcon.Internal;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Sockets;
 using System.Text.RegularExpressions;
 
-namespace rcon
+namespace rcon;
+
+[BepInPlugin("nl.avii.plugins.rcon", "rcon", "1.0.2")]
+public class rcon : BaseUnityPlugin
 {
-    [BepInPlugin("nl.avii.plugins.rcon", "rcon", "1.0")]
-    public class rcon : BaseUnityPlugin
+    public delegate string UnknownCommand(string command, string[] args);
+    public event UnknownCommand? OnUnknownCommand;
+
+    public delegate string ParamsAction(params string[] args);
+    private AsynchronousSocketListener? _socketListener;
+
+    private readonly ConfigEntry<bool> _enabled;
+    private readonly ConfigEntry<int> _port;
+    private readonly ConfigEntry<string> _password;
+
+    private readonly Dictionary<string, Type> _commands = new();
+    private readonly Dictionary<string, ParamsAction> _customCommands = new();
+
+    private readonly Dictionary<string, BaseUnityPlugin> _owners = new();
+
+    private rcon()
     {
-        public delegate string UnknownCommand(string command, string[] args);
-        public event UnknownCommand OnUnknownCommand;
+        _enabled = Config.Bind("rcon", "enabled", false, "Enable RCON Communication");
+        _port = Config.Bind("rcon", "port", 2458, "Port to use for RCON Communication");
+        _password = Config.Bind("rcon", "password", "ChangeMe", "Password to use for RCON Communication");
+    }
 
-        public delegate string ParamsAction(params object[] args);
-        private AsynchronousSocketListener socketListener;
+    private void OnEnable()
+    {
+        if (!_enabled.Value) return;
+        _socketListener = new AsynchronousSocketListener(IPAddress.Any, _port.Value);
+        _socketListener.OnMessage += SocketListener_OnMessage;
+        _socketListener.StartListening();
+        
+        Logger.LogInfo("RCON Listening on port: " + _port.Value);
+    }
 
-        private ConfigEntry<bool> Enabled;
-        private ConfigEntry<int> Port;
-        private ConfigEntry<string> Password;
-
-        private Dictionary<string, Type> commands = new Dictionary<string, Type>();
-        private Dictionary<string, ParamsAction> customCommands = new Dictionary<string, ParamsAction>();
-
-        private Dictionary<string, BaseUnityPlugin> owners = new Dictionary<string, BaseUnityPlugin>();
-
-        private rcon()
+    private void SocketListener_OnMessage(Socket socket, int requestId, PacketType type, string payload)
+    {
+        switch (type)
         {
-            Enabled = Config.Bind("rcon", "enabled", false, "Enable RCON Communication");
-            Port = Config.Bind("rcon", "port", 2458, "Port to use for RCON Communication");
-            Password = Config.Bind("rcon", "password", "ChangeMe", "Password to use for RCON Communication");
+            case PacketType.Login:
+
+                var responsePayload = "Login Success";
+                if (payload.Trim() != _password.Value.Trim())
+                {
+                    responsePayload = "Login Failed";
+                    requestId = -1;
+                }
+
+                byte[] packet = PacketBuilder.CreatePacket(requestId, PacketType.LoginResponse, responsePayload);
+
+                socket.Send(packet);
+                break;
+            case PacketType.Command:
+                // strip slash if present
+                if (payload[0] == '/')
+                {
+                    payload = payload.Substring(1);
+                }
+
+                var data = Regex.Matches(payload, @"(?<=[ ][\""]|^[\""])[^\""]+(?=[\""][ ]|[\""]$)|(?<=[ ]|^)[^\"" ]+(?=[ ]|$)")
+                    .Cast<Match>()
+                    .Select(m => m.Value)
+                    .ToList();
+
+                string command = data[0].ToLower();
+                data.RemoveAt(0);
+
+                if (!_commands.ContainsKey(command) && !_customCommands.ContainsKey(command))
+                {
+                    var ret = OnUnknownCommand?.Invoke(command, data.ToArray()) ?? string.Empty;
+                    var cmd = PacketType.Command;
+                    if (ret.ToLower().Contains("unknown"))
+                        cmd = PacketType.Error;
+
+                    socket.Send(PacketBuilder.CreatePacket(requestId, cmd, ret));
+                    return;
+                }
+
+                if (_commands.TryGetValue(command, out var t))
+                {
+                    var instance = (ICommand) Activator.CreateInstance(t);
+                    instance.setOwner(_owners[command]);
+                    var response = instance.onCommand(data.ToArray());
+                    socket.Send(PacketBuilder.CreatePacket(requestId, type, response));
+                }
+                else if (_customCommands.TryGetValue(command, out var customCommand))
+                {
+                    var response = customCommand(data.ToArray());
+                    socket.Send(PacketBuilder.CreatePacket(requestId, type, response));
+                }
+                break;
+            default:
+                Logger.LogError($"Unknown packet type: {type}");
+                break;
+        }
+    }
+
+    private void Update()
+    {
+        if (!_enabled.Value) return;
+        if (_socketListener == null) return;
+
+        _socketListener.Update();
+    }
+
+    private void OnDisable()
+    {
+        if (!_enabled.Value) return;
+        _socketListener?.Close();
+    }
+
+    public void RegisterCommand<T>(BaseUnityPlugin owner, string command) where T : AbstractCommand, new()
+    {
+        command = command.ToLower();
+        if (_owners.ContainsKey(command))
+        {
+            Logger.LogError($"{command} already registered");
+            return;
+        }
+        _owners[command] = owner;
+        _commands[command] = typeof(T);
+        Logger.LogInfo($"Registering Command: {command}");
+    }
+
+    public void RegisterCommand(BaseUnityPlugin owner, string command, ParamsAction action)
+    {
+        command = command.ToLower();
+        if (_owners.ContainsKey(command))
+        {
+            Logger.LogError($"{command} already registered");
+            return;
+        }
+        _owners[command] = owner;
+        _customCommands[command] = action;
+        Logger.LogInfo($"Registering Command: {command}");
+    }
+
+    public void UnRegisterCommand(BaseUnityPlugin owner, string command)
+    {
+        if (!_owners.ContainsKey(command))
+        {
+            return;
         }
 
-        private void OnEnable()
+        if (_owners[command] != owner)
         {
-            if (!Enabled.Value) return;
-            socketListener = new AsynchronousSocketListener();
-            socketListener.OnMessage += SocketListener_OnMessage;
-
-            Logger.LogInfo("RCON Listening on port: " + Port.Value);
-            socketListener.StartListening(Port.Value);
+            return;
         }
 
-        private void SocketListener_OnMessage(Socket socket, int requestId, PacketType type, string payload)
-        {
-            switch (type)
-            {
-                case PacketType.Login:
+        _owners.Remove(command);
 
-                    string response_payload = "Login Success";
-                    if (payload.Trim() != Password.Value.Trim())
-                    {
-                        response_payload = "Login Failed";
-                        requestId = -1;
-                    }
+        if (_commands.ContainsKey(command))
+            _commands.Remove(command);
 
-                    byte[] packet = PacketBuilder.CreatePacket(requestId, PacketType.LoginResponse, response_payload);
-
-                    socket.Send(packet);
-                    break;
-                case PacketType.Command:
-                    // strip slash if present
-                    if (payload[0] == '/')
-                    {
-                        payload = payload.Substring(1);
-                    }
-
-                    var data = Regex.Matches(payload, @"(?<=[ ][\""]|^[\""])[^\""]+(?=[\""][ ]|[\""]$)|(?<=[ ]|^)[^\"" ]+(?=[ ]|$)")
-                        .Cast<Match>()
-                        .Select(m => m.Value)
-                        .ToList();
-
-                    string command = data[0].ToLower();
-                    data.RemoveAt(0);
-
-                    if (!commands.ContainsKey(command) && !customCommands.ContainsKey(command))
-                    {
-                        var ret = OnUnknownCommand?.Invoke(command, data.ToArray());
-                        PacketType t = PacketType.Command;
-                        if (ret.ToLower().Contains("unknown"))
-                            t = PacketType.Error;
-
-                        socket.Send(PacketBuilder.CreatePacket(requestId, t, ret));
-                        return;
-                    }
-
-                    if (commands.ContainsKey(command))
-                    {
-                        var t = commands[command];
-                        var instance = (ICommand)Activator.CreateInstance(t);
-                        instance.setOwner(owners[command]);
-                        var response = instance.onCommand(data.ToArray());
-                        socket.Send(PacketBuilder.CreatePacket(requestId, type, response));
-                    }
-                    else if (customCommands.ContainsKey(command))
-                    {
-                        var response = customCommands[command](data.ToArray());
-                        socket.Send(PacketBuilder.CreatePacket(requestId, type, response));
-                    }
-                    break;
-                default:
-                    Logger.LogError($"Unknown packet type: {type}");
-                    break;
-            }
-        }
-
-        private void Update()
-        {
-            if (!Enabled.Value) return;
-            if (socketListener == null) return;
-
-            socketListener.Update();
-        }
-
-        private void OnDisable()
-        {
-            if (!Enabled.Value) return;
-            socketListener.Close();
-        }
-
-        public void RegisterCommand<T>(BaseUnityPlugin owner, string command) where T : AbstractCommand, new()
-        {
-            command = command.ToLower();
-            if (owners.ContainsKey(command))
-            {
-                Logger.LogError($"{command} already registered");
-                return;
-            }
-            owners[command] = owner;
-            commands[command] = typeof(T);
-            Logger.LogInfo($"Registering Command: {command}");
-        }
-
-        public void RegisterCommand(BaseUnityPlugin owner, string command, ParamsAction action)
-        {
-            command = command.ToLower();
-            if (owners.ContainsKey(command))
-            {
-                Logger.LogError($"{command} already registered");
-                return;
-            }
-            owners[command] = owner;
-            customCommands[command] = action;
-            Logger.LogInfo($"Registering Command: {command}");
-        }
-
-        public void UnRegisterCommand(BaseUnityPlugin owner, string command)
-        {
-            if (!owners.ContainsKey(command))
-            {
-                return;
-            }
-
-            if (owners[command] != owner)
-            {
-                return;
-            }
-
-            owners.Remove(command);
-
-            if (commands.ContainsKey(command))
-                commands.Remove(command);
-
-            if (customCommands.ContainsKey(command))
-                customCommands.Remove(command);
-        }
+        if (_customCommands.ContainsKey(command))
+            _customCommands.Remove(command);
     }
 }

--- a/rcon.csproj
+++ b/rcon.csproj
@@ -9,9 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>rcon</RootNamespace>
     <AssemblyName>rcon</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,8 +33,29 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BepInEx">
-      <HintPath>..\..\..\..\..\..\server\valheim\BepInEx\core\BepInEx.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.7.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\HarmonyX.2.7.0\lib\net45\0Harmony.dll</HintPath>
+    </Reference>
+    <Reference Include="BepInEx, Version=5.4.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\BepInEx.BaseLib.5.4.21\lib\net35\BepInEx.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>packages\Mono.Cecil.0.11.4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
+    <Reference Include="MonoMod.RuntimeDetour, Version=21.12.13.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\MonoMod.RuntimeDetour.21.12.13.1\lib\net452\MonoMod.RuntimeDetour.dll</HintPath>
+    </Reference>
+    <Reference Include="MonoMod.Utils, Version=21.12.13.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\MonoMod.Utils.21.12.13.1\lib\net452\MonoMod.Utils.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -42,11 +65,221 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\server\valheim\valheim_server_Data\Managed\UnityEngine.dll</HintPath>
+    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.dll</HintPath>
     </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\..\..\server\valheim\valheim_server_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+    <Reference Include="UnityEngine.AccessibilityModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.AccessibilityModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.AIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.AIModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.AndroidJNIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.AndroidJNIModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.AnimationModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.AnimationModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.AssetBundleModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.AssetBundleModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.AudioModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.AudioModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.ClothModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.ClothModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.ClusterInputModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.ClusterInputModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.ClusterRendererModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.ClusterRendererModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.CommandStateObserverModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.CommandStateObserverModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.ContentLoadModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.ContentLoadModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.CrashReportingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.CrashReportingModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.DirectorModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.DirectorModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.DSPGraphModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.DSPGraphModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.GameCenterModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.GameCenterModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.GIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.GIModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.GraphToolsFoundationModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.GraphToolsFoundationModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.GridModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.GridModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.HierarchyCoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.HierarchyCoreModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.HotReloadModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.HotReloadModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.ImageConversionModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.ImageConversionModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.IMGUIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.IMGUIModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.InputForUIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.InputForUIModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.InputLegacyModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.InputLegacyModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.InputModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.InputModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.JSONSerializeModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.JSONSerializeModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.LocalizationModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.LocalizationModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.MarshallingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.MarshallingModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.MultiplayerModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.MultiplayerModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.ParticleSystemModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.ParticleSystemModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.PerformanceReportingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.PerformanceReportingModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.Physics2DModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.Physics2DModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.PhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.PhysicsModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.ProfilerModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.ProfilerModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.PropertiesModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.PropertiesModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.RuntimeInitializeOnLoadManagerInitializerModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.RuntimeInitializeOnLoadManagerInitializerModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.ScreenCaptureModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.ScreenCaptureModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.SharedInternalsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.SharedInternalsModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.SpriteMaskModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.SpriteMaskModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.SpriteShapeModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.SpriteShapeModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.StreamingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.StreamingModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.SubstanceModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.SubstanceModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.SubsystemsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.SubsystemsModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.TerrainModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.TerrainModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.TerrainPhysicsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.TerrainPhysicsModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.TextCoreFontEngineModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.TextCoreFontEngineModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.TextCoreTextEngineModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.TextCoreTextEngineModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.TextRenderingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.TextRenderingModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.TilemapModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.TilemapModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.TLSModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.TLSModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UIElementsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.UIElementsModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UIModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.UIModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UmbraModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.UmbraModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UnityAnalyticsCommonModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.UnityAnalyticsCommonModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UnityAnalyticsModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.UnityAnalyticsModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UnityConnectModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.UnityConnectModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UnityCurlModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.UnityCurlModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UnityTestProtocolModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.UnityTestProtocolModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestAssetBundleModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.UnityWebRequestAssetBundleModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestAudioModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.UnityWebRequestAudioModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.UnityWebRequestModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestTextureModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.UnityWebRequestTextureModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UnityWebRequestWWWModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.VehiclesModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.VehiclesModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.VFXModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.VFXModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.VideoModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.VideoModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.VirtualTexturingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.VirtualTexturingModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.VRModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.VRModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.WindModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.WindModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.XRModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\UnityEngine.Modules.2023.2.14\lib\net45\UnityEngine.XRModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -59,8 +292,19 @@
     <Compile Include="Internal\StateObject.cs" />
     <Compile Include="rcon.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /y $(TargetDir)$(TargetFileName) C:\server\valheim\BepInEx\plugins\</PostBuildEvent>
+    <PostBuildEvent>copy /y $(TargetDir)$(TargetFileName) C:\Projects\ValheimDev\Valheim\BepInEx\plugins\</PostBuildEvent>
   </PropertyGroup>
+  <Import Project="packages\BepInEx.Core.5.4.21\build\BepInEx.Core.targets" Condition="Exists('packages\BepInEx.Core.5.4.21\build\BepInEx.Core.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\BepInEx.Core.5.4.21\build\BepInEx.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\BepInEx.Core.5.4.21\build\BepInEx.Core.targets'))" />
+  </Target>
 </Project>


### PR DESCRIPTION
Moved the BeginAccept call out of the main Update loop and put it in the StartListening and Accept callback instead.  This prevents the memory from being allocated each loop cycle of update.