### PR TITLE
Additional fixes for addressing memory leak

### DIFF
--- a/Internal/AsynchronousSocketListener.cs
+++ b/Internal/AsynchronousSocketListener.cs
@@ -56,9 +56,8 @@ internal class AsynchronousSocketListener(IPAddress ipAddress, int port)
         }
     }
 
-    internal void Update()
+    internal void Cleanup()
     {
-
         // copy the original list to an array to prevent errors when removing from the original list.
         foreach (var state in _clients.ToArray()) 
             if (!IsConnected(state.WorkSocket))
@@ -67,11 +66,8 @@ internal class AsynchronousSocketListener(IPAddress ipAddress, int port)
                 state.WorkSocket?.Close();
                 _clients.Remove(state);
             }
-        
-        // memory leak when called inside the Update loop, instead call it after AcceptCallback
-        //_listener?.BeginAccept(AcceptCallback, _listener);
     }
-
+    
     internal void AcceptCallback(IAsyncResult ar)
     {
         // Signal the main thread to continue.  

--- a/rcon.cs
+++ b/rcon.cs
@@ -10,7 +10,7 @@ using System.Text.RegularExpressions;
 
 namespace rcon;
 
-[BepInPlugin("nl.avii.plugins.rcon", "rcon", "1.0.2")]
+[BepInPlugin("nl.avii.plugins.rcon", "rcon", "1.0.3")]
 public class rcon : BaseUnityPlugin
 {
     public delegate string UnknownCommand(string command, string[] args);
@@ -35,6 +35,11 @@ public class rcon : BaseUnityPlugin
         _password = Config.Bind("rcon", "password", "ChangeMe", "Password to use for RCON Communication");
     }
 
+    private void Awake()
+    {
+        InvokeRepeating(nameof(Cleanup), 1f, 1f);
+    }
+
     private void OnEnable()
     {
         if (!_enabled.Value) return;
@@ -45,6 +50,11 @@ public class rcon : BaseUnityPlugin
         Logger.LogInfo("RCON Listening on port: " + _port.Value);
     }
 
+    private void Cleanup()
+    {
+        _socketListener?.Cleanup();
+    }
+    
     private void SocketListener_OnMessage(Socket socket, int requestId, PacketType type, string payload)
     {
         switch (type)
@@ -106,15 +116,7 @@ public class rcon : BaseUnityPlugin
                 break;
         }
     }
-
-    private void Update()
-    {
-        if (!_enabled.Value) return;
-        if (_socketListener == null) return;
-
-        _socketListener.Update();
-    }
-
+    
     private void OnDisable()
     {
         if (!_enabled.Value) return;

--- a/rcon.cs
+++ b/rcon.cs
@@ -17,7 +17,7 @@ public class rcon : BaseUnityPlugin
     public event UnknownCommand? OnUnknownCommand;
 
     public delegate string ParamsAction(params string[] args);
-    private AsynchronousSocketListener? _socketListener;
+    private readonly AsynchronousSocketListener _socketListener;
 
     private readonly ConfigEntry<bool> _enabled;
     private readonly ConfigEntry<int> _port;
@@ -33,6 +33,7 @@ public class rcon : BaseUnityPlugin
         _enabled = Config.Bind("rcon", "enabled", false, "Enable RCON Communication");
         _port = Config.Bind("rcon", "port", 2458, "Port to use for RCON Communication");
         _password = Config.Bind("rcon", "password", "ChangeMe", "Password to use for RCON Communication");
+        _socketListener = new AsynchronousSocketListener(IPAddress.Any, _port.Value);
     }
 
     private void Awake()
@@ -43,7 +44,6 @@ public class rcon : BaseUnityPlugin
     private void OnEnable()
     {
         if (!_enabled.Value) return;
-        _socketListener = new AsynchronousSocketListener(IPAddress.Any, _port.Value);
         _socketListener.OnMessage += SocketListener_OnMessage;
         _socketListener.StartListening();
         
@@ -52,7 +52,7 @@ public class rcon : BaseUnityPlugin
 
     private void Cleanup()
     {
-        _socketListener?.Cleanup();
+        _socketListener.Cleanup();
     }
     
     private void SocketListener_OnMessage(Socket socket, int requestId, PacketType type, string payload)

--- a/rcon.cs
+++ b/rcon.cs
@@ -34,6 +34,7 @@ public class rcon : BaseUnityPlugin
         _port = Config.Bind("rcon", "port", 2458, "Port to use for RCON Communication");
         _password = Config.Bind("rcon", "password", "ChangeMe", "Password to use for RCON Communication");
         _socketListener = new AsynchronousSocketListener(IPAddress.Any, _port.Value);
+        _socketListener.OnMessage += SocketListener_OnMessage;
     }
 
     private void Awake()
@@ -44,9 +45,7 @@ public class rcon : BaseUnityPlugin
     private void OnEnable()
     {
         if (!_enabled.Value) return;
-        _socketListener.OnMessage += SocketListener_OnMessage;
         _socketListener.StartListening();
-        
         Logger.LogInfo("RCON Listening on port: " + _port.Value);
     }
 
@@ -120,7 +119,7 @@ public class rcon : BaseUnityPlugin
     private void OnDisable()
     {
         if (!_enabled.Value) return;
-        _socketListener?.Close();
+        _socketListener.Close();
     }
 
     public void RegisterCommand<T>(BaseUnityPlugin owner, string command) where T : AbstractCommand, new()


### PR DESCRIPTION
There was some additional code in the main Update loop that was contributing to further cause memory leak.  I moved it into a Cleanup routine that is called once per second to close expired sessions.  Plus a few other minor fixes to get rid of any potential null refs.